### PR TITLE
Add manifest.json and PWA meta tags

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -1,0 +1,52 @@
+{
+  "name": "Fasting Tracker",
+  "short_name": "Fasting",
+  "description": "A mobile-first intermittent fasting app with live timers, weekly goals, and progress tracking.",
+  "start_url": "/dashboard",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "theme_color": "#0d1117",
+  "background_color": "#0d1117",
+  "icons": [
+    {
+      "src": "/static/img/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/img/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/img/icon-maskable-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/static/img/icon-maskable-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ],
+  "categories": ["health", "productivity"],
+  "screenshots": [
+    {
+      "src": "/static/img/screenshot-540x720.png",
+      "sizes": "540x720",
+      "type": "image/png",
+      "form_factor": "narrow"
+    },
+    {
+      "src": "/static/img/screenshot-1280x720.png",
+      "sizes": "1280x720",
+      "type": "image/png",
+      "form_factor": "wide"
+    }
+  ]
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,9 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="description" content="A mobile-first intermittent fasting app with live timers, weekly goals, and progress tracking.">
+    <meta name="theme-color" content="#0d1117">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Fasting">
+    <meta name="mobile-web-app-capable" content="yes">
     <title>{% block title %}Fasting Tracker{% endblock %}</title>
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect fill='%230d1117' width='192' height='192'/><circle cx='96' cy='96' r='80' fill='none' stroke='%233b6de0' stroke-width='20' stroke-dasharray='32 48' stroke-linecap='round'/><circle cx='96' cy='96' r='32' fill='%233b6de0' opacity='0.4'/></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">


### PR DESCRIPTION
Resolves #2

## Changes
- Created manifest.json with:
  - App identity (name, short name, description)
  - Icons at 192x192 and 512x512 with maskable variants
  - Display mode set to 'standalone' (hides browser chrome)
  - Theme colors matching the midnight dark theme
  - Start URL pointing to /dashboard
  - Portrait-primary orientation

- Updated base.html template:
  - Added link to manifest.json
  - Added PWA meta tags (theme-color, description, etc.)
  - Improved mobile web app status bar styling
  - Added SVG favicon for consistent branding

This enables better home screen installation on mobile devices, proper app icon display, and a native app-like experience with the browser chrome hidden.