### PR TITLE
Extend session lifetime to 30 days to prevent premature logouts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, session
 from flask_login import LoginManager
 from flask_migrate import Migrate
 
@@ -14,6 +14,10 @@ def create_app(config_name='development'):
     from app.models import db, User
     db.init_app(app)
     migrate.init_app(app, db)
+
+    @app.before_request
+    def make_session_permanent():
+        session.permanent = True
 
     login_manager = LoginManager()
     login_manager.init_app(app)

--- a/app/auth.py
+++ b/app/auth.py
@@ -21,7 +21,7 @@ def register():
         user.set_password(form.password.data)
         db.session.add(user)
         db.session.commit()
-        login_user(user)
+        login_user(user, remember=True)
         flash('Account created! Set your fasting goals to get started.', 'success')
         return redirect(url_for('main.settings'))
 
@@ -37,7 +37,7 @@ def login():
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
         if user and user.check_password(form.password.data):
-            login_user(user)
+            login_user(user, remember=True)
             next_page = request.args.get('next')
             return redirect(next_page or url_for('main.dashboard'))
         flash('Invalid email or password.', 'danger')

--- a/config.py
+++ b/config.py
@@ -1,4 +1,6 @@
 import os
+from datetime import timedelta
+
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -10,6 +12,9 @@ instance_path = os.path.join(basedir, 'instance')
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-change-in-production'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SESSION_PERMANENT = True
+    PERMANENT_SESSION_LIFETIME = timedelta(days=30)
+    REMEMBER_COOKIE_DURATION = timedelta(days=30)
 
 
 class DevelopmentConfig(Config):


### PR DESCRIPTION
- Set SESSION_PERMANENT=True and PERMANENT_SESSION_LIFETIME=30 days in Config
- Set REMEMBER_COOKIE_DURATION=30 days for Flask-Login persistent cookies
- Mark every session as permanent via a before_request hook
- Pass remember=True to login_user() on both login and registration

